### PR TITLE
Disable workflow execution during pull requests

### DIFF
--- a/.github/workflows/good_food_develop_workflow.yaml
+++ b/.github/workflows/good_food_develop_workflow.yaml
@@ -3,7 +3,6 @@ name: good_food_develop workflow
 on:
   push:
     branches: [main, develop]
-  pull_request:
 
 jobs:
 

--- a/.github/workflows/good_food_features_workflow.yaml
+++ b/.github/workflows/good_food_features_workflow.yaml
@@ -3,7 +3,6 @@ name: good_food_features workflow
 on:
   push:
     branches-ignore: [main, develop]
-  pull_request:
 
 jobs:
 


### PR DESCRIPTION
Отключить выполнение обоих workflow при создании pull request.
Иначе у нас происходит замена образа в DockerHub еще до одобрения pull request.

Disable execution of both workflows when creating a pull request.
Otherwise, we are replacing the image in DockerHub even before the pull request is approved.