### PR TITLE
Feature/stripe redirection

### DIFF
--- a/.github/workflows/good_food_workflow.yaml
+++ b/.github/workflows/good_food_workflow.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     needs: flake8_and_tests
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/good_food_workflow.yaml
+++ b/.github/workflows/good_food_workflow.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     needs: flake8_and_tests
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/backend/api/orders_views.py
+++ b/backend/api/orders_views.py
@@ -498,10 +498,11 @@ class OrderViewSet(
                 status=status.HTTP_403_FORBIDDEN,
             )
         stripe.api_key = settings.STRIPE_SECRET_KEY
-        if settings.MODE == "dev":
-            domain_url = f"http://{get_current_site(request)}/"
+        current_site = get_current_site(request)
+        if settings.MODE == "dev" or current_site.domain == "localhost":
+            domain_url = f"http://{current_site}/"
         else:
-            domain_url = f"https://{get_current_site(request)}/"
+            domain_url = f"https://{current_site}/"
         try:
             checkout_session = stripe.checkout.Session.create(
                 line_items=[

--- a/backend/api/orders_views.py
+++ b/backend/api/orders_views.py
@@ -516,8 +516,8 @@ class OrderViewSet(
                         "quantity": 1,
                     }
                 ],
-                success_url=domain_url + "success",
-                cancel_url=domain_url + "cancel",
+                success_url=domain_url + "catalog",
+                cancel_url=domain_url + "contacts",
                 client_reference_id=request.user.username
                 if request.user.is_authenticated
                 else None,


### PR DESCRIPTION
Временно изменила success_url на страницу Каталога и cancel_url на страницу Контакты во время платежа stripe (когда фронтендеры сверстают страницы успеха/неуспеха, поменяю success_url и cancel_url на нужные пути.
Исправила баг переадресации на success_url в случае запкуска проекта в docker-контейнерах на localhost.