### PR TITLE
Feature/stripe redirection

### DIFF
--- a/.github/workflows/good_food_workflow.yaml
+++ b/.github/workflows/good_food_workflow.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     needs: flake8_and_tests
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/good_food_workflow.yaml
+++ b/.github/workflows/good_food_workflow.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     needs: flake8_and_tests
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/backend/api/orders_serializers.py
+++ b/backend/api/orders_serializers.py
@@ -291,3 +291,36 @@ class StripeCheckoutSessionCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Order
         fields = tuple()
+
+
+class StripeSessionCreateSerializer(serializers.Serializer):
+    """Serializer to show Stripe Checkout Session URL."""
+
+    checkout_session_url = serializers.URLField()
+
+
+class StripePaySuccessPageSerializer(serializers.Serializer):
+    """Serializer to get the order number from Stripe Checkout Session after payment."""
+
+    stripe_session_id = serializers.CharField()
+    order_id = serializers.CharField(read_only=True)
+    order_number = serializers.CharField(read_only=True)
+
+
+class StripeError500Serializer(serializers.Serializer):
+    """Serializer for errors during Stripe payments."""
+
+    message = serializers.CharField()
+    errors = serializers.CharField()
+
+
+class CustomSuccessSerializer(serializers.Serializer):
+    """Serializer for custom success messages."""
+
+    message = serializers.CharField()
+
+
+class CustomErrorSerializer(serializers.Serializer):
+    """Serializer for custom errors."""
+
+    errors = serializers.CharField()

--- a/backend/api/orders_views.py
+++ b/backend/api/orders_views.py
@@ -559,8 +559,9 @@ class OrderViewSet(
                     }
                 ],
                 success_url=domain_url
-                + "payment-results?session_id={CHECKOUT_SESSION_ID}",
-                cancel_url=domain_url + "cart",
+                + "payment-is-processing?session_id={CHECKOUT_SESSION_ID}",
+                cancel_url=domain_url
+                + "payment-cancelled?session_id={CHECKOUT_SESSION_ID}",
                 client_reference_id=request.user.username
                 if request.user.is_authenticated
                 else None,

--- a/backend/payments/urls.py
+++ b/backend/payments/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
         views.create_checkout_session,
         name="create-checkout-session",
     ),
-    path("success/", views.SuccessView.as_view()),
-    path("cancel/", views.CancelledView.as_view()),
+    path("payment-good/", views.SuccessView.as_view()),
+    path("payment-bad/", views.CancelledView.as_view()),
     path("webhooks/stripe/", views.stripe_webhook, name="stripe-webhook"),
 ]

--- a/backend/payments/urls.py
+++ b/backend/payments/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
         views.create_checkout_session,
         name="create-checkout-session",
     ),
-    path("payment-good/", views.SuccessView.as_view()),
-    path("payment-bad/", views.CancelledView.as_view()),
+    path("payment-is-processing/", views.SuccessView.as_view()),
+    path("payment-cancelled/", views.CancelledView.as_view()),
     path("webhooks/stripe/", views.stripe_webhook, name="stripe-webhook"),
 ]

--- a/backend/tests/api_tests/test_order.py
+++ b/backend/tests/api_tests/test_order.py
@@ -150,4 +150,4 @@ class TestOrder:
         assert response.status_code == status.HTTP_201_CREATED
         order = Order.objects.get()
         response = client.delete(f"/api/order/{order.order_number}/", format="json")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
1. Исправила эндпойнт удаления заказа - раньше для анонима заказ искался по номеру заказа (хотя вместо номера вставлялся id заказа, это осталось еще с тех пор, когда номер заказа равнялся его id, а теперь в этом месте сервер начал падать), а для авторизованного искался по id. Теперь для анонима сразу выкидывается статус 401 и сообщение об ошибке. А для авторизованого мы ищем заказ по id и проверяем, принадлежит ли он ему, если да - удаляем, если нет - статус 403 и сообщение об ошибке.
2. Явно прописала, что отмена заказа анонимом невозможна (она и раньше не была возможна, но это было неявно, и выкидывался статус 403, теперь будет статус 401 unauthorized).
3. Исправила название сообщения о невозможности удаления уже комплектующегося заказа (раньше оно называлось DELIVERY_ERROR_MESSAGE, но у нас было также другое DELIVERY_ERROR_MESSAGE в orders_serializers.py с другим текстом, получалась путанница).
4. Создала сериализаторы для кастомных ошибок (CustomErrorSerializer с полем "errors") и для кастомного сообщения об успехе (CustomSuccessSerializer с полем "message"). Подключила CustomErrorSerializer в тех случаях, когда мы кидаем собственное сообщение об ошибке вида {"errors": some message}. CustomSuccessSerializer подключен к эндпойнту /shopping_cart/remove_all/.
5. В файле orders_views.py перенесла все декораторы swagger_auto_schema из @action-эндпойнтов в самое начало вьюсета, чтобы все декораторы swagger_auto_schema были вместе ДО начала кода самого вьюсета и не встречались внутри него (чтобы повысить читабельность кода). Исправила в них responses, где они не соответствовали действительным ответам апи. Описания перенесла на уровень методов (если методы были переопределены) и скорректировала, где была указана старая информация.
6. Поменяла эндпойнт /order/{id}/pay/ - подключила CustomErrorSerializer и StripeError500Serializer для сериализации ошибок 4хх и 500, поменяла success_url и cancel_url, добавила номер заказа в поле metadata.
7. Создала эндпойнт /order/successful_pay/, который принимает на вход Stripe CHECKOUT_SESSION_ID и отдает id и номер заказа, который оплачивался в рамках Stripe Checkout Session с данным CHECKOUT_SESSION_ID. Предполагается, что этот эндпойнт будет подключен к stripe success_url, чтобы мы могли на ней отобразить номер оплаченного заказа.
8. Обновила статус код в тесте test_delete_order_anonimus_client.